### PR TITLE
Use PR title for Beachball commits

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -67,7 +67,7 @@ jobs:
         if: inputs.beachball
         run: |
           pnpm beachball change \
-            --message "chore(deps): ${{ github.event.pull_request.title }}" \
+            --message "${{ github.event.pull_request.title }}" \
             --no-commit \
             --type patch \
             --yes


### PR DESCRIPTION
Use PR title as-is for Beachball commits.

See: https://docs.renovatebot.com/configuration-templates/#pr-title.
