### PR TITLE
Make registry URL optional when publishing packages

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -9,7 +9,6 @@ on:
       registry-url:
         type: string
         default: https://registry.npmjs.org
-        required: true
       scope:
         type: string
         required: false


### PR DESCRIPTION
Ensures registry URL doesn't need to be provided.

Fixes #16.