### PR TITLE
Move TypeScript checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -144,10 +144,6 @@ jobs:
         if: inputs.prettier
         run: pnpm prettier --check .
 
-      - name: TypeScript
-        if: inputs.typescript
-        run: pnpm tsc --build .
-
       - name: Beachball
         if: github.event_name == 'pull_request' && inputs.beachball
         run: |
@@ -188,6 +184,10 @@ jobs:
             git diff
             exit 1
           fi
+
+      - name: TypeScript
+        if: inputs.typescript
+        run: pnpm tsc --build .
 
   vitest:
     name: Vitest


### PR DESCRIPTION
Moves TypeScript checks, avoiding issues with dirtying the working tree for commands that are requiring pristine clean porcelain checks.