### PR TITLE
Always run Vitest checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -193,7 +193,7 @@ jobs:
     name: Vitest
     runs-on: ubuntu-latest
     needs: [commit-upgrade-changes]
-    if: inputs.vitest
+    if: always() && inputs.vitest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Always run Vitest checks if enabled.

Fixes issue with job not running for skipped dependencies.

Fixes #9.