### PR TITLE
Use OIDC trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -13,8 +13,6 @@ on:
         type: string
         required: false
     secrets:
-      NPM_TOKEN:
-        required: true
       REPO_TOKEN:
         required: true
 
@@ -23,6 +21,9 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -37,6 +38,9 @@ jobs:
           registry-url: ${{ inputs.registry-url }}
           scope: ${{ inputs.scope }}
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Configure Git user
         uses: langri-sha/github/actions/github-action-bot-git-user@v0.4.0
 
@@ -44,8 +48,6 @@ jobs:
         run: pnpm tsc --build .
 
       - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           pnpm beachball publish \
             --access public \


### PR DESCRIPTION
Switches the reusable packages workflow to authenticate with npm via GitHub OIDC instead of a long-lived `NPM_TOKEN` secret.

Changes:
- Grant `id-token: write` on the publish job (calling workflows must also grant it for it to reach here).
- Drop the `NPM_TOKEN` required secret and the `NODE_AUTH_TOKEN` env on the publish step.
- Upgrade npm on the runner to `npm@latest` — Node 20 ships npm 10.x by default, OIDC trusted publishing requires npm >= 11.5.1.

Beachball calls `npm publish` under the hood, so no beachball changes are needed; the recent npm CLI handles the OIDC token exchange transparently.

Paired with langri-sha/langri-sha.com#1034 and tracked by langri-sha/langri-sha.com#1033.

References:
- npm Docs: https://docs.npmjs.com/trusted-publishers/
- GitHub blog: https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/