### PR TITLE
Bump pnpm/action-setup and actions/setup-node to Node 24 versions

### DIFF
--- a/actions/pnpm/action.yml
+++ b/actions/pnpm/action.yml
@@ -30,7 +30,7 @@ runs:
 
   steps:
     - name: Setup PNPM
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@v6
       with:
         run_install: false
 

--- a/actions/pnpm/action.yml
+++ b/actions/pnpm/action.yml
@@ -35,7 +35,7 @@ runs:
         run_install: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         always-auth: ${{ inputs.always-auth }}
         cache: pnpm


### PR DESCRIPTION
Both pinned actions still run on Node 20 and surface deprecation warnings on
every workflow run. Forced Node 24 hits June 2, 2026; Node 20 is removed from
runners on September 16, 2026.

- \`pnpm/action-setup@v3\` → \`@v6\`
- \`actions/setup-node@v4\` → \`@v6\`

Both live in \`actions/pnpm/action.yml\`. The existing \`cache: pnpm\` input
keeps working — setup-node v6 limits its new automatic caching to npm only.
\`run_install: false\` on pnpm/action-setup is still supported in v6.

## Refs

- [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- [pnpm/action-setup v6.0.8 release](https://github.com/pnpm/action-setup/releases/tag/v6.0.8)
- [actions/setup-node v6.0.0 release](https://github.com/actions/setup-node/releases/tag/v6.0.0)