### PR TITLE
Use a GitHub App token for the post-upgrade push

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,6 +31,13 @@ on:
         description: Run Vitest checks.
         type: boolean
         default: false
+    secrets:
+      APP_ID:
+        description: GitHub App ID used for the post-upgrade push.
+        required: false
+      APP_PRIVATE_KEY:
+        description: GitHub App private key used for the post-upgrade push.
+        required: false
 
 jobs:
   post-upgrade:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -102,10 +102,18 @@ jobs:
       contents: write
 
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Download diff
         uses: actions/download-artifact@v4
@@ -113,7 +121,14 @@ jobs:
           name: diff
 
       - name: Configure Git user
-        uses: langri-sha/github/actions/github-action-bot-git-user@v0.4.0
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          BOT_NAME="${APP_SLUG}[bot]"
+          BOT_ID=$(gh api "/users/${BOT_NAME}" -q .id)
+          git config user.name  "${BOT_NAME}"
+          git config user.email "${BOT_ID}+${BOT_NAME}@users.noreply.github.com"
 
       - name: Apply diff
         run: |


### PR DESCRIPTION
Closes #44.

## Summary

- Mint an installation token via `actions/create-github-app-token@v2` in `commit-upgrade-changes` using caller-supplied `APP_ID` / `APP_PRIVATE_KEY` secrets.
- Pass that token to `actions/checkout` so the follow-up push authenticates as the App.
- Configure git author/email from the App's `app-slug` so the commit matches the push identity. Drops the `github-action-bot-git-user@v0.4.0` step.

Callers will need `secrets: inherit` (or explicit passes) on their `check.yml` job and the two repo secrets set.

## Test plan

- [ ] Cut a release and have a downstream repo (e.g. `langri-sha.com`) pin to it, then verify Renovate PRs get checks on the post-mutation head commit.
