### PR TITLE
Harden the post-upgrade self-mutation flow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,12 +44,16 @@ jobs:
     name: Renovate Post-Upgrade
     runs-on: ubuntu-latest
 
-    if: github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]')
+    permissions:
+      contents: read
     outputs:
       has-changes: ${{ steps.git-changes.outputs.has-changes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup PNPM
         uses: langri-sha/github/actions/pnpm@v0.3.0
@@ -102,7 +106,7 @@ jobs:
   commit-upgrade-changes:
     name: Commit Upgrade Changes
     runs-on: ubuntu-latest
-    if: ${{ needs.post-upgrade.outputs.has-changes }}
+    if: needs.post-upgrade.outputs.has-changes == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]')
     needs: [post-upgrade]
 
     permissions:
@@ -115,6 +119,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Checkout
         uses: actions/checkout@v6
@@ -126,6 +131,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: diff
+
+      - name: Reject unsafe paths in patch
+        run: |
+          git apply --check .diff.patch
+          if git apply --numstat .diff.patch | awk -F '\t' '{print $3}' | grep -E '^\.github/(workflows|actions)/'; then
+            echo '::error::Generated post-upgrade patches may not modify GitHub Actions files.'
+            exit 1
+          fi
 
       - name: Configure Git user
         env:
@@ -149,12 +162,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [commit-upgrade-changes]
     if: always()
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
 
       - name: Setup PNPM
         uses: langri-sha/github/actions/pnpm@v0.3.0
@@ -217,10 +233,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [commit-upgrade-changes]
     if: always() && inputs.vitest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup PNPM
         uses: langri-sha/github/actions/pnpm@v0.3.0


### PR DESCRIPTION
## Summary

Defense-in-depth hardening of the Renovate post-upgrade self-mutation chain in `check.yml`. The original fork-PR exfiltration concern is closed at the GitHub level (secrets are stripped from `pull_request` workflows triggered by forks), but the workflow itself made several unnecessarily broad trust assumptions. This PR tightens them.

## Changes

- **Same-repo head gate** on both `post-upgrade` and `commit-upgrade-changes`: the chain only runs when `pull_request.head.repo.full_name == github.repository`. Belt-and-braces with GitHub's existing secret stripping.
- **Least-privilege job permissions**: `post-upgrade`, `lint`, `vitest` drop to `contents: read`. Only `commit-upgrade-changes` keeps `contents: write`.
- **`persist-credentials: false`** on every checkout that runs project-tree code (`post-upgrade`, `lint`, `vitest`). Prevents lifecycle scripts (postinstall, eslint configs, vitest tests, etc.) from harvesting the default `GITHUB_TOKEN`.
- **Narrow the App token's installation permissions** to `contents: write` only via `permission-contents: write` on `create-github-app-token`.
- **Reject patches that touch `.github/workflows/**` or `.github/actions/**`** before `git apply` runs. Protects against a compromised dependency in `post-upgrade` smuggling workflow modifications through the bot push.

## Threat model recap

| Scenario | Before | After |
|---|---|---|
| Fork PR tries to read `APP_PRIVATE_KEY` | Blocked by GitHub (secrets stripped) | Blocked by GitHub + same-repo gate |
| Fork PR steals default `GITHUB_TOKEN` from lint/vitest | Possible | Blocked by `persist-credentials: false` |
| Same-repo Renovate PR with malicious transitive dep smuggles a workflow change | Possible (patch was applied blindly) | Blocked by path-allowlist reject |
| Leaked App token's blast radius | Whatever the installation grants | Narrowed to `contents: write` |

## Notes for callers

No interface change — `secrets: APP_ID` / `APP_PRIVATE_KEY` and `secrets: inherit` continue to work exactly as before.

## Test plan

- [ ] After release, rebase one Renovate PR (e.g. langri-sha.com#1041) and confirm the chain still succeeds end-to-end (post-upgrade → bot push → `pull_request` workflows refire on the bot's SHA, all green).
- [ ] Verify the reject step would catch a `.github/workflows/foo.yml` change by manually pushing such a patch and watching `commit-upgrade-changes` fail at the new step (can be done in a throwaway branch on a fork).
