### PR TITLE
Add a terraform-version input to the terraform action

### DIFF
--- a/actions/terraform/action.yml
+++ b/actions/terraform/action.yml
@@ -12,6 +12,12 @@ inputs:
       The working directory to use for reading the Terraform configuration.
       Defaults to the current working directory.
     required: false
+  terraform-version:
+    description: |-
+      The Terraform version to install. When set, takes precedence over the
+      version auto-detected from `required_version` in the working directory's
+      *.tf files. Falls back to that auto-detection, then to `latest`.
+    required: false
 
 runs:
   using: composite
@@ -29,7 +35,7 @@ runs:
         echo "terraform-version=$(rg "required_version = \"(\d+\.\d+\.\d+)\"" -t tf -or '$1' --no-filename | tail -1)" >> $GITHUB_OUTPUT
 
     - name: Warn missing version
-      if: steps.version.outputs.terraform-version == ''
+      if: inputs.terraform-version == '' && steps.version.outputs.terraform-version == ''
       shell: bash
       run: |
         echo "::warning::Missing Terraform version"
@@ -37,8 +43,7 @@ runs:
     - name: Setup
       uses: hashicorp/setup-terraform@v3
       with:
-        terraform_version:
-          ${{ steps.version.outputs.terraform-version || 'latest' }}
+        terraform_version: ${{ inputs.terraform-version || steps.version.outputs.terraform-version || 'latest' }}
 
     - name: Initialize
       shell: bash


### PR DESCRIPTION
## Summary

Adds an optional `terraform-version` input to `actions/terraform`. When set, it takes precedence over the existing `required_version` auto-detection. Falls back to auto-detect, then to `latest` with a warning, exactly as before.

## Motivation

The auto-detection (ripgrep over `*.tf` files for `required_version = "X.Y.Z"`) silently fails in real-world conditions — non-exact constraints, missing file-type registration, working-directory mismatches — and the fallback to `latest` causes `setup-terraform` to install whatever ships today, breaking projects pinned to older versions. The recently observed failure on `langri-sha.com#1045` is an example: the auto-extract returned empty, `latest` installed Terraform 1.15.5, and `terraform validate` rejected configurations pinned to `required_version = "1.9.5"`.

Letting callers pass the version explicitly is more robust than depending on regex extraction.

## Usage

```yaml
- uses: langri-sha/github/actions/terraform@<release>
  with:
    working-directory: terraform/web
    terraform-version: 1.9.5
```

## Test plan

- [ ] After release, bump the consumer's `terraform-version: 1.9.5` on `langri-sha.com/.github/workflows/terraform.yml` and confirm the validate step succeeds against the existing `required_version = "1.9.5"` pin.
