### PR TITLE
Fix post-upgrade Beachball staging

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -74,6 +74,10 @@ jobs:
         if: inputs.projen
         run: pnpm projen
 
+      - name: Stage generated changes
+        if: inputs.beachball
+        run: git add -A
+
       - name: Create Beachball changes
         if: inputs.beachball
         run: |
@@ -82,6 +86,10 @@ jobs:
             --no-commit \
             --type patch \
             --yes
+
+      - name: Check Beachball changes
+        if: inputs.beachball
+        run: pnpm beachball check
 
       - name: Check for Git changes
         id: git-changes


### PR DESCRIPTION
## Summary

- stage generated post-upgrade edits before running `beachball change`
- run `beachball check` immediately after generating change files

## Why

`beachball change` only accounts for committed and staged changes. The post-upgrade job previously ran formatter/projen fixes, then generated Beachball change files before staging those generated edits. The later patch step staged everything, so formatter changes could be committed without matching change files and fail the downstream Beachball check.

## Testing

- `git diff --check`